### PR TITLE
Fix typo in verify_hostname.ex

### DIFF
--- a/lib/hex/http/verify_hostname.ex
+++ b/lib/hex/http/verify_hostname.ex
@@ -59,7 +59,7 @@ defmodule Hex.HTTP.VerifyHostname do
     if check_hostname = state[:check_hostname] do
       verify_cert_hostname(cert, check_hostname)
     else
-      {:valud, state}
+      {:valid, state}
     end
   end
 


### PR DESCRIPTION
Just stumbled across this, don't think this is intended :)